### PR TITLE
ignore language settings & empty h1 errors

### DIFF
--- a/ignore.yaml
+++ b/ignore.yaml
@@ -18,9 +18,9 @@
     type: notice
   # Django Debug Toolbar
   - context: '*class="djDebugClose"*'
-  # Language Selector
-  - context: '*class="settings-language-form"*'
   # Logo h1 is not actually empty (it contains an img with alt text)
+  # This is technically an erroneous rule in HTML CodeSniffer, so we should
+  # remove it once we upgrade to the latest ruleset.
   - message: >-
       Heading tag found with no content. Text that is not intended as a
       heading should not be marked up with heading tags.

--- a/ignore.yaml
+++ b/ignore.yaml
@@ -18,3 +18,10 @@
     type: notice
   # Django Debug Toolbar
   - context: '*class="djDebugClose"*'
+  # Language Selector
+  - context: '*class="settings-language-form"*'
+  # Logo h1 is not actually empty (it contains an img with alt text)
+  - message: >-
+      Heading tag found with no content. Text that is not intended as a
+      heading should not be marked up with heading tags.
+    selector: '#global-navigation > nav > h1'


### PR DESCRIPTION
So far, here are the new additions:
- Completely ignore any violations reported on the language settings selector:
<img width="1217" alt="screen shot 2017-01-23 at 3 56 51 pm" src="https://cloud.githubusercontent.com/assets/491289/22222555/4ec2081a-e185-11e6-8381-f5ac12c1c1fe.png">

- Ignore the "h1 tag with no content" violation on the logo `<h1>`, since it technically does contain content (the `<img>` tag)

This is related to https://openedx.atlassian.net/browse/AC-701 and https://github.com/edx/edx-platform/pull/14369.